### PR TITLE
Property manager details in listing form may 22

### DIFF
--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.js
@@ -47,6 +47,7 @@ export const EditListingDeliveryFormComponent = props => (
         pristine,
         invalid,
         listingTypeConfig,
+        listingCategoryConfig,
         marketplaceCurrency,
         hasStockInUse,
         saveActionMsg,
@@ -69,7 +70,7 @@ export const EditListingDeliveryFormComponent = props => (
       const { pauseValidation, resumeValidation } = form;
       pauseValidation(false);
       useEffect(() => resumeValidation(), [values]);
-
+      
       const displayShipping = displayDeliveryShipping(listingTypeConfig);
       const displayPickup = displayDeliveryPickup(listingTypeConfig);
       const displayMultipleDelivery = displayShipping && displayPickup;
@@ -109,6 +110,10 @@ export const EditListingDeliveryFormComponent = props => (
         [css.hidden]: !displayShipping,
       });
       const currencyConfig = appSettings.getCurrencyFormatting(marketplaceCurrency);
+
+      //we only show property fields if this is a secured location
+      const showPropertyManagerFields = ['location','location-machine', 'atm-location'].indexOf(listingCategoryConfig.id) >= 0;
+      const propertyManagerFields = ['businessName', 'managerName', 'managerPhone', 'managerEmail'];
 
       return (
         <Form className={classes} onSubmit={handleSubmit}>
@@ -181,6 +186,34 @@ export const EditListingDeliveryFormComponent = props => (
               disabled={!pickupEnabled}
             />
           </div>
+
+          {showPropertyManagerFields && (
+            <>
+              <h4 className={css.sectionHeading}>
+                <FormattedMessage id="EditListingDeliveryForm.propertyManagerFieldsHeading" />
+              </h4>
+              {propertyManagerFields.map(fieldName => (
+                <FieldTextInput
+                  key={fieldName}
+                  className={css.input}
+                  type="text"
+                  name={fieldName}
+                  id={`${formId}.${fieldName}`}
+                  label={intl.formatMessage({ id: `EditListingDeliveryForm.${fieldName}` })}
+                  placeholder={intl.formatMessage({
+                    id: `EditListingDeliveryForm.${fieldName}Placeholder`,
+                  })}
+                  validate={
+                    required(
+                      intl.formatMessage({
+                        id: `EditListingDeliveryForm.${fieldName}Required`,
+                      })
+                    )
+                  }
+                />
+              ))}
+            </>
+          )}
 
           <FieldCheckbox
             id={formId ? `${formId}.shipping` : 'shipping'}
@@ -263,16 +296,19 @@ export const EditListingDeliveryFormComponent = props => (
               />
             ) : null}
           </div>
+          <div className={css.buttonWrapper}>
 
-          <Button
-            className={css.submitButton}
-            type="submit"
-            inProgress={submitInProgress}
-            disabled={submitDisabled}
-            ready={submitReady}
-          >
-            {saveActionMsg}
-          </Button>
+            <Button
+              className={css.submitButton}
+              type="submit"
+              inProgress={submitInProgress}
+              disabled={submitDisabled}
+              ready={submitReady}
+            >
+              {saveActionMsg}
+            </Button>
+            
+          </div>
         </Form>
       );
     }}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.js
@@ -26,6 +26,8 @@ import {
   FieldCheckbox,
 } from '../../../../components';
 
+import { Info } from 'lucide-react';
+
 // Import modules from this directory
 import css from './EditListingDeliveryForm.module.css';
 
@@ -192,6 +194,11 @@ export const EditListingDeliveryFormComponent = props => (
               <h4 className={css.sectionHeading}>
                 <FormattedMessage id="EditListingDeliveryForm.propertyManagerFieldsHeading" />
               </h4>
+              <div className={css.propertyManagerNote}>
+                <Info className={css.infoIcon} /> 
+                <FormattedMessage id="EditListingDeliveryForm.propertyManagerNote" />
+              </div>
+
               {propertyManagerFields.map(fieldName => (
                 <FieldTextInput
                   key={fieldName}
@@ -307,7 +314,7 @@ export const EditListingDeliveryFormComponent = props => (
             >
               {saveActionMsg}
             </Button>
-            
+
           </div>
         </Form>
       );

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.module.css
@@ -106,3 +106,15 @@
     }
   }
 }
+
+svg.infoIcon {
+  margin-right: 5px;
+  width: 13px;
+  height: 13px;
+}
+
+.propertyManagerNote {
+  color: var(--colorGrey500);
+  margin-bottom: 40px;
+  font-size: 13px;
+}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryForm.module.css
@@ -85,6 +85,24 @@
   @media (--viewportLarge) {
     display: inline-block;
     width: 241px;
-    margin-top: 100px;
+  }
+}
+
+.buttonWrapper {
+  @media (--viewportLarge) {
+    position:sticky;
+    padding-top: 20px;
+    background:white;
+    bottom:0;
+    :before {
+      content: '';
+      pointer-events: none;
+      position: absolute;
+      top: -40px;
+      left: 0;
+      right: 0;
+      height: 40px;
+      background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+    }
   }
 }

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.js
@@ -10,6 +10,7 @@ import { types as sdkTypes } from '../../../../util/sdkLoader';
 
 // Import shared components
 import { H3, ListingLink } from '../../../../components';
+import { Info } from 'lucide-react';
 
 // Import modules from this directory
 import EditListingDeliveryForm from './EditListingDeliveryForm';
@@ -31,7 +32,7 @@ const getInitialValues = props => {
   // TODO bounds are missing - those need to be queried directly from Google Places
   const locationFieldsPresent = publicData?.location?.address && geolocation;
   const location = publicData?.location || {};
-  const { address, building } = location;
+  const { address, building, businessName, managerName, managerPhone, managerEmail } = location;
   const {
     shippingEnabled,
     pickupEnabled,
@@ -60,6 +61,10 @@ const getInitialValues = props => {
   // Initial values for the form
   return {
     building,
+    businessName,
+    managerName,
+    managerPhone,
+    managerEmail,
     location: locationFieldsPresent
       ? {
           search: address,
@@ -110,19 +115,25 @@ const EditListingDeliveryPanel = props => {
 
   return (
     <div className={classes}>
-      <H3 as="h1">
-        {isPublished ? (
-          <FormattedMessage
-            id="EditListingDeliveryPanel.title"
-            values={{ listingTitle: <ListingLink listing={listing} />, lineBreak: <br /> }}
-          />
-        ) : (
-          <FormattedMessage
-            id="EditListingDeliveryPanel.createListingTitle"
-            values={{ lineBreak: <br /> }}
-          />
-        )}
-      </H3>
+        <H3 as="h1">
+          {isPublished ? (
+            <FormattedMessage
+              id="EditListingDeliveryPanel.title"
+              values={{ listingTitle: <ListingLink listing={listing} />, lineBreak: <br /> }}
+            />
+          ) : (
+            <FormattedMessage
+              id="EditListingDeliveryPanel.createListingTitle"
+              values={{ lineBreak: <br /> }}
+            />
+          )}
+        </H3>
+        
+        <div className={css.sideNote}>
+          <Info className={css.infoIcon} /> 
+          <FormattedMessage id="EditListingDeliveryPanel.sideNote" />
+        </div>
+
       {priceCurrencyValid ? (
         <EditListingDeliveryForm
           className={css.form}
@@ -130,6 +141,10 @@ const EditListingDeliveryPanel = props => {
           onSubmit={values => {
             const {
               building = '',
+              businessName = '',
+              managerName = '',
+              managerPhone = '',
+              managerEmail = '',
               location,
               shippingPriceInSubunitsOneItem,
               shippingPriceInSubunitsAdditionalItems,
@@ -142,7 +157,7 @@ const EditListingDeliveryPanel = props => {
             const origin = location?.selectedPlace?.origin || null;
 
             const pickupDataMaybe =
-              pickupEnabled && address ? { location: { address, building } } : {};
+              pickupEnabled && address ? { location: { address, building, businessName, managerName, managerPhone, managerEmail } } : {};
 
             const shippingDataMaybe =
               shippingEnabled && shippingPriceInSubunitsOneItem != null
@@ -172,6 +187,10 @@ const EditListingDeliveryPanel = props => {
             setState({
               initialValues: {
                 building,
+                businessName,
+                managerName,
+                managerPhone,
+                managerEmail,
                 location: { search: address, selectedPlace: { address, origin } },
                 shippingPriceInSubunitsOneItem,
                 shippingPriceInSubunitsAdditionalItems,
@@ -181,6 +200,7 @@ const EditListingDeliveryPanel = props => {
             onSubmit(updateValues);
           }}
           listingTypeConfig={listingTypeConfig}
+          listingCategoryConfig={listingCategoryConfig}
           marketplaceCurrency={marketplaceCurrency}
           hasStockInUse={hasStockInUse}
           saveActionMsg={submitButtonText}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.js
@@ -129,9 +129,9 @@ const EditListingDeliveryPanel = props => {
           )}
         </H3>
         
-        <div className={css.sideNote}>
+        <div className={css.locationNote}>
           <Info className={css.infoIcon} /> 
-          <FormattedMessage id="EditListingDeliveryPanel.sideNote" />
+          <FormattedMessage id="EditListingDeliveryPanel.locationNote" />
         </div>
 
       {priceCurrencyValid ? (

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.module.css
@@ -15,3 +15,12 @@
 .priceCurrencyInvalid {
   color: var(--colorFail);
 }
+
+.infoIcon {
+  margin-right: 5px;
+}
+
+.sideNote {
+  color: var(--colorGrey500);
+  margin-bottom: 40px;
+}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDeliveryPanel/EditListingDeliveryPanel.module.css
@@ -16,11 +16,14 @@
   color: var(--colorFail);
 }
 
-.infoIcon {
+svg.infoIcon {
   margin-right: 5px;
+  width: 13px;
+  height: 13px;
 }
 
-.sideNote {
+.locationNote {
   color: var(--colorGrey500);
   margin-bottom: 40px;
+  font-size: 13px;
 }

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
@@ -542,6 +542,7 @@ const EditListingDetailsFormComponent = props => (
             </p>
           )}
 
+          <div className={css.buttonWrapper}>
           <Button
             className={css.submitButton}
             type="submit"
@@ -551,6 +552,7 @@ const EditListingDetailsFormComponent = props => (
           >
             {saveActionMsg}
           </Button>
+          </div>
         </Form>
       );
     }}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.module.css
@@ -72,6 +72,24 @@
   @media (--viewportLarge) {
     display: inline-block;
     width: 241px;
-    margin-top: 100px;
+  }
+}
+
+.buttonWrapper {
+  @media (--viewportLarge) {
+    position:sticky;
+    padding-top: 20px;
+    background:white;
+    bottom:0;
+    :before {
+      content: '';
+      pointer-events: none;
+      position: absolute;
+      top: -40px;
+      left: 0;
+      right: 0;
+      height: 40px;
+      background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+    }
   }
 }

--- a/src/extensions/transactionProcesses/components/TransactionModalForm/TransactionModalForm.js
+++ b/src/extensions/transactionProcesses/components/TransactionModalForm/TransactionModalForm.js
@@ -15,6 +15,7 @@ const getField = ({ config, configIndex, intl, values }) => {
     labelTranslationId,
     placeholderTranslationId,
     name,
+    initialValue,
     validators: validatorsConfig = [],
   } = config;
 
@@ -32,6 +33,7 @@ const getField = ({ config, configIndex, intl, values }) => {
           id={name}
           name={name}
           type="text"
+          initialValue={initialValue}
           label={labelTranslationId && intl.formatMessage({ id: labelTranslationId })}
           placeholder={
             placeholderTranslationId && intl.formatMessage({ id: placeholderTranslationId })
@@ -66,6 +68,7 @@ const getField = ({ config, configIndex, intl, values }) => {
           placeholder={
             placeholderTranslationId && intl.formatMessage({ id: placeholderTranslationId })
           }
+          initialValue={initialValue}
           useDefaultPredictions={false}
           format={v => v}
           valueFromForm={values[name]}

--- a/src/extensions/transactionProcesses/sellPurchase/stateData/TransactionPage.stateDataSellPurchase.js
+++ b/src/extensions/transactionProcesses/sellPurchase/stateData/TransactionPage.stateDataSellPurchase.js
@@ -114,6 +114,8 @@ export const getStateDataForSellPurchaseProcess = (txInfo, processInfo) => {
 
   const { categoryLevel1: rawCategoryLevel1 } = transaction.listing.attributes.publicData;
   const categoryLevel1 = rawCategoryLevel1?.replaceAll('-', '_');
+  const listingLocation = transaction?.listing?.attributes?.publicData?.location;
+  const listingGeolocation = transaction?.listing?.attributes?.geolocation;
 
   const {
     isCustomer,
@@ -176,7 +178,7 @@ export const getStateDataForSellPurchaseProcess = (txInfo, processInfo) => {
       };
     })
     .cond([states.PURCHASE_CONFIRMED_BY_BUYER, PROVIDER], () => {
-      const getFieldTextConfig = (name, validators = []) => ({
+      const getFieldTextConfig = (name, validators = [], initialValue = '') => ({
         type: FIELD_TEXT,
         labelTranslationId: `TransactionPage.sell-purchase.${name}.label`,
         name: `protectedData.${name}`,
@@ -187,6 +189,7 @@ export const getStateDataForSellPurchaseProcess = (txInfo, processInfo) => {
           },
           ...validators,
         ],
+        initialValue,
       });
 
       return {
@@ -196,16 +199,16 @@ export const getStateDataForSellPurchaseProcess = (txInfo, processInfo) => {
           isConfirmNeeded: true,
           showReminderStatement: true,
           formConfigs: [
-            getFieldTextConfig('managerBusinessName'),
-            getFieldTextConfig('managerName'),
-            getFieldTextConfig('managerPhoneNumber'),
+            getFieldTextConfig('managerBusinessName', [], listingLocation?.businessName ),
+            getFieldTextConfig('managerName', [], listingLocation?.managerName),
+            getFieldTextConfig('managerPhoneNumber', [], listingLocation?.managerPhone),
             getFieldTextConfig('managerEmail', [
               {
                 validatorFn: emailFormatValid,
                 messageTranslationId:
                   'TransactionPage.sell-purchase.managerEmail.emailInvalidMesage',
               },
-            ]),
+            ], listingLocation?.managerEmail),
             {
               type: FIELD_LOCATION,
               labelTranslationId: 'TransactionPage.sell-purchase.managerAddress.label',
@@ -222,6 +225,13 @@ export const getStateDataForSellPurchaseProcess = (txInfo, processInfo) => {
                     'TransactionPage.sell-purchase.managerAddress.placeInvalidMessage',
                 },
               ],
+              initialValue: {
+                search:listingLocation?.address,
+                selectedPlace: {
+                  address: listingLocation?.address,
+                  origin: listingGeolocation,
+                },
+              },
             },
           ],
           confirmModalTitleTranslationId:

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -225,7 +225,23 @@
   "EditListingDeliveryForm.shippingOneItemRequired": "Shipping fee for one item required.",
   "EditListingDeliveryForm.showListingFailed": "Fetching listing data failed.",
   "EditListingDeliveryForm.updateFailed": "Failed to update listing. Please try again.",
+  "EditListingDeliveryForm.propertyManagerFieldsHeading": "Business information",
+  "EditListingDeliveryForm.businessName": "Business name",
+  "EditListingDeliveryForm.businessNamePlaceholder": "John's Barber Shop",
+  "EditListingDeliveryForm.businessNameRequired": "Business name is required",
+  "EditListingDeliveryForm.managerName": "Property manager's name",
+  "EditListingDeliveryForm.managerNamePlaceholder": "John Doe",
+  "EditListingDeliveryForm.managerNameRequired": "Manager's name is required",
+  "EditListingDeliveryForm.managerPhone": "Manager's phone number",
+  "EditListingDeliveryForm.managerPhonePlaceholder": "(555) 555-5555",
+  "EditListingDeliveryForm.managerPhoneRequired": "Manager's phone number is required",
+  "EditListingDeliveryForm.managerEmail": "Manager's email",
+  "EditListingDeliveryForm.managerEmailPlaceholder": "john.doe@example.com",
+  "EditListingDeliveryForm.managerEmailRequired": "Manager's email is required",
+  "EditListingDeliveryForm.propertyManagerNote": "Business/contact details are not shared until you make the introduction",
+
   "EditListingDeliveryPanel.createListingTitle": "Location",
+  "EditListingDeliveryPanel.locationNote": "Exact location is only displayed to a buyer after purchase",
   "EditListingDeliveryPanel.title": "Edit the location of {listingTitle}",
   "EditListingDetailsForm.categoryLabel": "{categoryLevel, select, categoryLevel1 {Category} other {Subcategory}}",
   "EditListingDetailsForm.categoryPlaceholder": "{categoryLevel, select, categoryLevel1 {Select category} other {Select subcategory}}",
@@ -1196,6 +1212,8 @@
   "SearchRequestLinks.or": "or",
   "SocialProofReviews.title": "4.9/5 Reviews",
   "SocialProofReviews.caption": "Overall average for buyers and sellers",
-  "AgentApplyNow.buttonLabel": "Apply now"
+  "AgentApplyNow.buttonLabel": "Apply now",
+ "AuthenticationPage.login.toastTitle": "Welcome back!",
+  "AuthenticationPage.login.toastContent": "You're all set to buy and sell locations."
 
 }

--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -208,8 +208,15 @@ export const sanitizeListing = (entity, config = {}) => {
   const { title, description, publicData, ...restAttributes } = attributes || {};
 
   const sanitizeLocation = location => {
-    const { address, building } = location || {};
-    return { address: sanitizeText(address), building: sanitizeText(building) };
+    const { address, building, businessName, managerName, managerPhone, managerEmail } = location || {};
+    return { 
+      address: sanitizeText(address), 
+      building: sanitizeText(building), 
+      businessName: sanitizeText(businessName), 
+      managerName: sanitizeText(managerName), 
+      managerPhone: sanitizeText(managerPhone), 
+      managerEmail: sanitizeText(managerEmail) 
+    };
   };
 
   const sanitizePublicData = publicData => {


### PR DESCRIPTION
Updated the "location" tab of the listing form with all the business/manager fields

Essentially for "Location", "Location with Machine" and "ATM at Location" the Business Info fields will display and will be required.

However, nothing changed for the actual "into buyer to manager" 
1.  we have to leave it as is at least for the Bids/Services anyways
2.  it does some other logic like send the details by email, 
3. it includes confirmation for the seller to acknowledge that they're representing the property

So what i've done for now is just pre-populate the form with whatever is set here (if it's been set - i.e. after this goes live and a new listing is created or existing listing is edited)

So if these fields have been filled out, when the seller clicks "intro buyer to manager" the form will be pre-filled and they just need to click submit.

Technically: the details stored here in the listing and and the details stored in the "intro buyer" modal form are separate storages of information. So even if the seller changes the listing after the intro is made, the originally submitted "intro" form will still be all the buyer sees.

We are still determining if the transaction-saved details are needed, or if it should always just leverage these newly created publicData location fields.. TBD